### PR TITLE
Add GitHub Actions CI, wheel building, and docs workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
           sub-packages: '["nvcc", "cudart"]'
 
       - name: Install Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: jakoch/install-vulkan-sdk-action@v1.0.5
         with:
-          vulkan-query-version: 1.3.290.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          vulkan_version: 1.3.290.0
+          install_runtime: false
+          cache: true
 
       - name: Build and install
         run: pip install . -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.27
+        with:
+          cuda: "12.6.0"
+          method: network
+          sub-packages: '["nvcc", "cudart"]'
+
+      - name: Install Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.290.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+
+      - name: Build and install
+        run: pip install . -v
+
+      - name: Verify import
+        run: python -c "import touchpy; print(f'touchpy {touchpy.__version__} OK')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install CUDA Toolkit
         shell: powershell
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           cuda: "12.6.0"
           method: network
           sub-packages: '["nvcc", "cudart"]'
+          use-github-cache: false
+          use-local-cache: false
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
           python-version: "3.12"
 
       - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.27
-        with:
-          cuda: "12.6.0"
-          method: network
-          sub-packages: '["nvcc", "cudart"]'
-          use-github-cache: false
-          use-local-cache: false
+        shell: powershell
+        run: |
+          $url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe"
+          Invoke-WebRequest -Uri $url -OutFile cuda_installer.exe
+          Start-Process -FilePath .\cuda_installer.exe -ArgumentList '-s','nvcc_12.6','cudart_12.6' -Wait -NoNewWindow
+          echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6" >> $env:GITHUB_ENV
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin" >> $env:GITHUB_PATH
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,24 @@ jobs:
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Cache CUDA Toolkit
+        id: cache-cuda
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6
+          key: cuda-12.6.0-nvcc-cudart
+
       - name: Install CUDA Toolkit
+        if: steps.cache-cuda.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           $url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe"
           Invoke-WebRequest -Uri $url -OutFile cuda_installer.exe
           Start-Process -FilePath .\cuda_installer.exe -ArgumentList '-s','nvcc_12.6','cudart_12.6' -Wait -NoNewWindow
+
+      - name: Set CUDA environment
+        shell: powershell
+        run: |
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6" >> $env:GITHUB_ENV
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin" >> $env:GITHUB_PATH
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build and install
         run: pip install . -v
+        env:
+          CMAKE_GENERATOR: Ninja
 
       - name: Verify import
         run: python -c "import touchpy; print(f'touchpy {touchpy.__version__} OK')"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install CUDA Toolkit
         shell: powershell
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Build and install touchpy
         run: pip install . -v
+        env:
+          CMAKE_GENERATOR: Ninja
 
       - name: Install docs dependencies
         run: pip install -r docs/requirements.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
           cuda: "12.6.0"
           method: network
           sub-packages: '["nvcc", "cudart"]'
+          use-github-cache: false
+          use-local-cache: false
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,13 +16,13 @@ jobs:
           python-version: "3.12"
 
       - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.27
-        with:
-          cuda: "12.6.0"
-          method: network
-          sub-packages: '["nvcc", "cudart"]'
-          use-github-cache: false
-          use-local-cache: false
+        shell: powershell
+        run: |
+          $url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe"
+          Invoke-WebRequest -Uri $url -OutFile cuda_installer.exe
+          Start-Process -FilePath .\cuda_installer.exe -ArgumentList '-s','nvcc_12.6','cudart_12.6' -Wait -NoNewWindow
+          echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6" >> $env:GITHUB_ENV
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin" >> $env:GITHUB_PATH
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,11 +23,11 @@ jobs:
           sub-packages: '["nvcc", "cudart"]'
 
       - name: Install Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: jakoch/install-vulkan-sdk-action@v1.0.5
         with:
-          vulkan-query-version: 1.3.290.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          vulkan_version: 1.3.290.0
+          install_runtime: false
+          cache: true
 
       - name: Build and install touchpy
         run: pip install . -v

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,24 @@ jobs:
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Cache CUDA Toolkit
+        id: cache-cuda
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6
+          key: cuda-12.6.0-nvcc-cudart
+
       - name: Install CUDA Toolkit
+        if: steps.cache-cuda.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           $url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe"
           Invoke-WebRequest -Uri $url -OutFile cuda_installer.exe
           Start-Process -FilePath .\cuda_installer.exe -ArgumentList '-s','nvcc_12.6','cudart_12.6' -Wait -NoNewWindow
+
+      - name: Set CUDA environment
+        shell: powershell
+        run: |
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6" >> $env:GITHUB_ENV
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin" >> $env:GITHUB_PATH
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.27
+        with:
+          cuda: "12.6.0"
+          method: network
+          sub-packages: '["nvcc", "cudart"]'
+
+      - name: Install Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.290.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+
+      - name: Build and install touchpy
+        run: pip install . -v
+
+      - name: Install docs dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build documentation
+        run: sphinx-build -M html docs/source docs/build
+
+      - name: Deploy to docs branch
+        uses: peaceiris/actions-gh-pages@v4
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html
+          publish_branch: docs
+          force_orphan: false

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,8 @@ jobs:
           cuda: "12.6.0"
           method: network
           sub-packages: '["nvcc", "cudart"]'
+          use-github-cache: false
+          use-local-cache: false
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,12 +19,24 @@ jobs:
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Cache CUDA Toolkit
+        id: cache-cuda
+        uses: actions/cache@v4
+        with:
+          path: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6
+          key: cuda-12.6.0-nvcc-cudart
+
       - name: Install CUDA Toolkit
+        if: steps.cache-cuda.outputs.cache-hit != 'true'
         shell: powershell
         run: |
           $url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe"
           Invoke-WebRequest -Uri $url -OutFile cuda_installer.exe
           Start-Process -FilePath .\cuda_installer.exe -ArgumentList '-s','nvcc_12.6','cudart_12.6' -Wait -NoNewWindow
+
+      - name: Set CUDA environment
+        shell: powershell
+        run: |
           echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6" >> $env:GITHUB_ENV
           echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin" >> $env:GITHUB_PATH
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -24,11 +24,11 @@ jobs:
           sub-packages: '["nvcc", "cudart"]'
 
       - name: Install Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: jakoch/install-vulkan-sdk-action@v1.0.5
         with:
-          vulkan-query-version: 1.3.290.0
-          vulkan-components: Vulkan-Headers, Vulkan-Loader
-          vulkan-use-cache: true
+          vulkan_version: 1.3.290.0
+          install_runtime: false
+          cache: true
 
       - name: Build wheel
         uses: pypa/cibuildwheel@v2.22

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,97 @@
+name: Build Wheels
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build_wheels:
+    name: Build wheels (Python ${{ matrix.python }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install CUDA Toolkit
+        uses: Jimver/cuda-toolkit@v0.2.27
+        with:
+          cuda: "12.6.0"
+          method: network
+          sub-packages: '["nvcc", "cudart"]'
+
+      - name: Install Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.290.0
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+
+      - name: Build wheel
+        uses: pypa/cibuildwheel@v2.22
+        env:
+          CIBW_BUILD: "${{ matrix.python }}-win_amd64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.python }}
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  publish:
+    name: Publish to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist/
+          merge-multiple: true
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  upload_release_assets:
+    name: Upload release assets
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Upload wheels to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.27
-        with:
-          cuda: "12.6.0"
-          method: network
-          sub-packages: '["nvcc", "cudart"]'
-          use-github-cache: false
-          use-local-cache: false
+        shell: powershell
+        run: |
+          $url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/network_installers/cuda_12.6.0_windows_network.exe"
+          Invoke-WebRequest -Uri $url -OutFile cuda_installer.exe
+          Start-Process -FilePath .\cuda_installer.exe -ArgumentList '-s','nvcc_12.6','cudart_12.6' -Wait -NoNewWindow
+          echo "CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6" >> $env:GITHUB_ENV
+          echo "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.6\bin" >> $env:GITHUB_PATH
 
       - name: Install Vulkan SDK
         uses: jakoch/install-vulkan-sdk-action@v1.0.5

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           CIBW_BUILD: "${{ matrix.python }}-win_amd64"
           CIBW_ARCHS_WINDOWS: "AMD64"
+          CMAKE_GENERATOR: Ninja
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install CUDA Toolkit
         shell: powershell
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,12 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(VulkanMemoryAllocator)
 
+# Source includes VMA as "vma/vk_mem_alloc.h" (matching Vulkan SDK layout)
+# but the VMA repo puts it at include/vk_mem_alloc.h — create the expected structure
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/_vma_include/vma")
+file(COPY "${vulkanmemoryallocator_SOURCE_DIR}/include/vk_mem_alloc.h"
+     DESTINATION "${CMAKE_BINARY_DIR}/_vma_include/vma")
+
 # touchpy
 #################################################################################################
 find_package(Python 3.9
@@ -114,7 +120,7 @@ target_include_directories(touchpy PRIVATE
     ${SOURCE_DIR}
     ${CUDAToolkit_INCLUDE_DIRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/external/TouchEngine-Windows/include"
-    "${vulkanmemoryallocator_SOURCE_DIR}/include"
+    "${CMAKE_BINARY_DIR}/_vma_include"
 )
 
 target_link_directories(touchpy PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(spdlog)
 
+FetchContent_Declare(
+  VulkanMemoryAllocator
+  GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+  GIT_TAG v3.1.0
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+)
+FetchContent_MakeAvailable(VulkanMemoryAllocator)
+
 # touchpy
 #################################################################################################
 find_package(Python 3.9
@@ -105,6 +114,7 @@ target_include_directories(touchpy PRIVATE
     ${SOURCE_DIR}
     ${CUDAToolkit_INCLUDE_DIRS}
     "${CMAKE_CURRENT_SOURCE_DIR}/external/TouchEngine-Windows/include"
+    "${vulkanmemoryallocator_SOURCE_DIR}/include"
 )
 
 target_link_directories(touchpy PRIVATE

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
-BUILDDIR      = ../install/docs
+BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,6 @@
-sphinx==7.3.6 
-sphinx-autoapi==3.1.0b0
-furo==2024.1.29
+sphinx>=7.3
+sphinx-autoapi>=3.1
+furo
 sphinx-copybutton
+numpydoc
+myst_parser

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,18 +4,12 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 
-from pathlib import Path
-import sys
-localImportPath = Path.cwd().parents[1] / 'install/modules'
-
-if str(localImportPath) not in sys.path:
-	sys.path.insert(0,str(localImportPath))	
-
+from importlib.metadata import version as get_version
 
 project = 'TouchPy'
 copyright = '2024'
 author = 'IntentDev'
-release = '0.10'
+release = get_version('touchpy')
 
 
 #==== start autoapi variant ========================
@@ -28,7 +22,9 @@ extensions = ['sphinx.ext.autodoc',
           'numpydoc',
           'myst_parser']
 
-autoapi_dirs = ['../../out/install_build/py312']
+import touchpy
+import os
+autoapi_dirs = [os.path.dirname(touchpy.__file__)]
 autoapi_type = "python"
 
 autoapi_options = [ 'members', 'undoc-members', 'private-members', 'show-module-summary', 'special-members', 'imported-members', ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "nanobind>=2.4.0", "ninja"]
+requires = ["scikit-build-core>=0.10", "nanobind>=2.4.0"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "nanobind>=2.4.0"]
+requires = ["scikit-build-core>=0.10", "nanobind>=2.4.0", "ninja"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
@
## Summary
- **ci.yml**: Smoke test on push to main + PRs — builds for Python 3.12 with CUDA/Vulkan, verifies import
- **wheels.yml**: cibuildwheel matrix building Python 3.9-3.13 wheels on Windows. Triggered by GitHub Release or manual dispatch. Publishes to PyPI (trusted publishing) and uploads wheels as release assets.
- **docs.yml**: Builds Sphinx docs and deploys to `docs` branch (GitHub Pages). Triggered by release or manual dispatch.
- Updated `docs/source/conf.py` to use installed package instead of hardcoded build paths
- Updated `docs/requirements.txt` with missing dependencies
- VMA fetched via FetchContent for CI compatibility (full Vulkan SDK not required)
- CUDA Toolkit cached between runs via actions/cache
- Ninja generator used in CI (avoids need for CUDA VS integration)

Depends on #83 (Phase 1).

## Test plan
- [x] ci.yml runs automatically on PR — build + import succeeds
- [ ] Trigger wheels.yml manually from main — verify wheels built for all 5 Python versions
- [ ] Trigger docs.yml manually from main — verify docs build and deploy to docs branch
@